### PR TITLE
fix input

### DIFF
--- a/awsdebug.sh
+++ b/awsdebug.sh
@@ -17,10 +17,10 @@ fi
 indent(){ sed 's/^/  /'; }
 
 echo "What is the command or line of code you tried to run? Only type in a single line that is most relevant: "
-read command
+read command < /dev/tty
 
 echo "Copy and paste the error you got here. Only type in a single line: "
-read error
+read error < /dev/tty
 
 echo Gathering more debug information...
 identity=$(aws sts get-caller-identity 2>&1)


### PR DESCRIPTION
Problem:
When running the command in the readme, `curl -s 'https://raw.githubusercontent.com/ispot-tv/awsdebug/main/awsdebug.sh' | bash `, the input is not picked up. Command and error is blank. 

Fix: 
see https://stackoverflow.com/questions/6170598/can-anyone-explain-to-me-what-the-purpose-of-dev-tty
I verified the fix works both when piping the script to bash and running the script by itself